### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/mrasender-scm-1.rockspec
+++ b/mrasender-scm-1.rockspec
@@ -2,7 +2,7 @@ package = 'mrasender'
 version = '1.0.1'
 
 source  = {
-    url    = 'git://github.com/tarantool/mrasender.git';
+    url    = 'git+https://github.com/tarantool/mrasender.git';
     branch = 'master';
 }
 


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/